### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -90,6 +90,8 @@ jobs:
 
   package:
     name: Package Binaries
+    permissions:
+      contents: read
     needs: [auto-tag, build]
     runs-on: ubuntu-latest
     # Always run after build


### PR DESCRIPTION
Potential fix for [https://github.com/DFanso/commit-msg/security/code-scanning/2](https://github.com/DFanso/commit-msg/security/code-scanning/2)

The best way to fix this problem is to explicitly set the `permissions` key for the `package` job to limit the `GITHUB_TOKEN` to the minimum required permissions. Since the `package` job only handles artifact download and upload (and does not need to write to the repository or modify issues, PRs, etc.), it typically only requires `contents: read`. 

To implement this, add a `permissions:` block with `contents: read` at the beginning of the `package` job definition (under line 91). No other imports or changes are necessary; simply edit the YAML for the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
