### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -43,6 +43,8 @@ jobs:
 
   build:
     name: Build Go Binary
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     needs: auto-tag
     # Always run build, even if auto-tag was skipped (e.g., for tag pushes)


### PR DESCRIPTION
Potential fix for [https://github.com/DFanso/commit-msg/security/code-scanning/1](https://github.com/DFanso/commit-msg/security/code-scanning/1)

To fix this issue, we should add a `permissions` block to the `build` job in `.github/workflows/build-and-release.yml`. This block should grant only the minimum necessary permission, which for this job is `contents: read`. This ensures the `build` job cannot make changes to the repository, following the principle of least privilege. The addition should be placed alongside the other job keys, right after `name: Build Go Binary`, similar to how it is specified for the `auto-tag` and `package` jobs. No code changes or imports are needed, only a small YAML edit in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build workflow permissions to grant read access to repository contents during builds.
  * No changes to build steps, release flow, or deployment behavior.
  * No impact on features, UI, or performance; end-user experience remains unchanged.
  * This adjustment applies only to internal automation and infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->