### PR TITLE
Fix #39: Update Gemini API key references

### DIFF
--- a/cmd/commit-msg/main.go
+++ b/cmd/commit-msg/main.go
@@ -23,10 +23,10 @@ func main() {
     var apiKey string
 
     switch commitLLM {
-    case "google":
-        apiKey = os.Getenv("GOOGLE_API_KEY")
+    case "gemini":
+        apiKey = os.Getenv("GEMINI_API_KEY")
         if apiKey == "" {
-            log.Fatalf("GOOGLE_API_KEY is not set")
+            log.Fatalf("GEMINI_API_KEY is not set")
         }
     case "grok":
         apiKey = os.Getenv("GROK_API_KEY")
@@ -112,7 +112,7 @@ func main() {
 		}
 
 		var commitMsg string
-		if os.Getenv("COMMIT_LLM") == "google" {
+		if os.Getenv("COMMIT_LLM") == "gemini" {
 			commitMsg, err = gemini.GenerateCommitMessage(config, changes, apiKey)
 		} else if os.Getenv("COMMIT_LLM") == "chatgpt" {
 			commitMsg, err = chatgpt.GenerateCommitMessage(config, changes, apiKey)

--- a/internal/scrubber/scrubber.go
+++ b/internal/scrubber/scrubber.go
@@ -63,9 +63,9 @@ var (
 			Redact:  "${1}=\"[REDACTED_GITHUB_TOKEN]\"",
 		},
 		{
-			Name:    "Google API Key",
+			Name:    "Gemini API Key",
 			Pattern: regexp.MustCompile(`(?i)(google[_-]?api[_-]?key|GOOGLE_API_KEY|GEMINI_API_KEY)\s*[=:]\s*["\']?(AIza[a-zA-Z0-9_\-]{35})["\']?`),
-			Redact:  "${1}=\"[REDACTED_GOOGLE_API_KEY]\"",
+			Redact:  "${1}=\"[REDACTED_GEMINI_API_KEY]\"",
 		},
 		{
 			Name:    "OpenAI API Key",

--- a/internal/scrubber/scrubber_test.go
+++ b/internal/scrubber/scrubber_test.go
@@ -27,9 +27,9 @@ func TestScrubAPIKeys(t *testing.T) {
 			expected: `OPENAI_API_KEY="[REDACTED_OPENAI_KEY]"`,
 		},
 		{
-			name:     "Google API key",
-			input:    `GOOGLE_API_KEY="AIzaSyDabcdefghijklmnopqrstuvwxyz12345"`,
-			expected: `GOOGLE_API_KEY="[REDACTED_GOOGLE_API_KEY]"`,
+			name:     "Gemini API key",
+			input:    `GEMINI_API_KEY="AIzaSyDabcdefghijklmnopqrstuvwxyz12345"`,
+			expected: `GEMINI_API_KEY="[REDACTED_GEMINI_API_KEY]"`,
 		},
 		{
 			name:     "Claude API key",


### PR DESCRIPTION
- Replaces Google API key references with Gemini.
- Updates environment variable names and scrubber patterns.

<img width="799" height="559" alt="image" src="https://github.com/user-attachments/assets/93ac8b79-7889-4a3c-a6a6-4035f1e591c8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit message generation now supports the Gemini provider. Select it via COMMIT_LLM=gemini.

* **Refactor**
  * Configuration updated to use GEMINI_API_KEY instead of GOOGLE_API_KEY.

* **Chores**
  * Secret scrubbing updated to recognize and redact Gemini API keys, with labels reflecting the Gemini provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->