### PR TITLE
fix #22 : convert LLM provider selection to switch statement

### DIFF
--- a/cmd/commit-msg/main.go
+++ b/cmd/commit-msg/main.go
@@ -118,9 +118,7 @@ func main() {
 		case "chatgpt":
 			commitMsg, err = chatgpt.GenerateCommitMessage(config, changes, apiKey)
 		case "claude":
-			commitMsg, err = claude.GenerateCommitMessage(config, changes, apiKey)
-		case "grok":
-			commitMsg, err = grok.GenerateCommitMessage(config, changes, apiKey)
+			commitMsg, err = claude.GenerateCommitMessage(config, changes, apiKey)	
 		default:
 			commitMsg, err = grok.GenerateCommitMessage(config, changes, apiKey)
 		}


### PR DESCRIPTION
- Replaced if-else with switch statement to explicitly handle all providers (gemini, chatgpt, claude, grok)
- Used existing commitLLM variable instead of multiple os.Getenv calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Streamlined how the tool selects the AI provider for commit message generation for clearer, more maintainable behavior.
  - Added explicit handling for several popular provider options while preserving the existing fallback when unspecified or unrecognized.
  - No user configuration changes; outputs and performance remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->