### PR TITLE
fix #72 : Replace hardcoded display limits with named constants in ShowFileStatistics

### DIFF
--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -6,6 +6,12 @@ import (
 	"github.com/pterm/pterm"
 )
 
+const (
+	MaxStagedFiles    = 5
+	MaxUnstagedFiles  = 3
+	MaxUntrackedFiles = 3
+)
+
 // FileStatistics holds statistics about changed files
 type FileStatistics struct {
 	StagedFiles    []string
@@ -31,17 +37,17 @@ func ShowFileStatistics(stats *FileStatistics) {
 			BulletStyle: pterm.NewStyle(pterm.FgGreen),
 		})
 		for i, file := range stats.StagedFiles {
-			if i < 5 { // Show first 5 files
+			if i < MaxStagedFiles { // Show first 5 files
 				bulletItems = append(bulletItems, pterm.BulletListItem{
 					Level: 1,
 					Text:  file,
 				})
 			}
 		}
-		if len(stats.StagedFiles) > 5 {
+		if len(stats.StagedFiles) > MaxStagedFiles {
 			bulletItems = append(bulletItems, pterm.BulletListItem{
 				Level: 1,
-				Text:  pterm.Gray(fmt.Sprintf("... and %d more", len(stats.StagedFiles)-5)),
+				Text:  pterm.Gray(fmt.Sprintf("... and %d more", len(stats.StagedFiles)-MaxStagedFiles)),
 			})
 		}
 	}
@@ -54,17 +60,17 @@ func ShowFileStatistics(stats *FileStatistics) {
 			BulletStyle: pterm.NewStyle(pterm.FgYellow),
 		})
 		for i, file := range stats.UnstagedFiles {
-			if i < 3 {
+			if i < MaxUnstagedFiles {
 				bulletItems = append(bulletItems, pterm.BulletListItem{
 					Level: 1,
 					Text:  file,
 				})
 			}
 		}
-		if len(stats.UnstagedFiles) > 3 {
+		if len(stats.UnstagedFiles) > MaxUnstagedFiles {
 			bulletItems = append(bulletItems, pterm.BulletListItem{
 				Level: 1,
-				Text:  pterm.Gray(fmt.Sprintf("... and %d more", len(stats.UnstagedFiles)-3)),
+				Text:  pterm.Gray(fmt.Sprintf("... and %d more", len(stats.UnstagedFiles)-MaxUnstagedFiles)),
 			})
 		}
 	}
@@ -77,17 +83,17 @@ func ShowFileStatistics(stats *FileStatistics) {
 			BulletStyle: pterm.NewStyle(pterm.FgCyan),
 		})
 		for i, file := range stats.UntrackedFiles {
-			if i < 3 {
+			if i < MaxUntrackedFiles {
 				bulletItems = append(bulletItems, pterm.BulletListItem{
 					Level: 1,
 					Text:  file,
 				})
 			}
 		}
-		if len(stats.UntrackedFiles) > 3 {
+		if len(stats.UntrackedFiles) > MaxUntrackedFiles {
 			bulletItems = append(bulletItems, pterm.BulletListItem{
 				Level: 1,
-				Text:  pterm.Gray(fmt.Sprintf("... and %d more", len(stats.UntrackedFiles)-3)),
+				Text:  pterm.Gray(fmt.Sprintf("... and %d more", len(stats.UntrackedFiles)-MaxUntrackedFiles)),
 			})
 		}
 	}


### PR DESCRIPTION
- Add MaxStagedFiles, MaxUnstagedFiles, and MaxUntrackedFiles constants
- Update all references to use these constants instead of hardcoded values (5, 3, 3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized display limits for staged, unstaged, and untracked file lists, ensuring consistent visibility across categories.
  * Unified calculation of the “… and N more” summary so remaining item counts are displayed consistently.
  * Improves predictability of how many items are shown before truncation and how overflow is summarized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->