### PR TITLE
Feat/dry run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Looking to contribute? Check out:
 
 ✨ **AI-Powered Commit Messages** - Automatically generate meaningful commit messages  
 🔄 **Multiple LLM Support** - Choose between Google Gemini, Grok, Claude, ChatGPT, or Ollama (local)  
+🧪 **Dry Run Mode** - Preview prompts without making API calls  
 📝 **Context-Aware** - Analyzes staged and unstaged changes  
 📋 **Auto-Copy to Clipboard** - Generated messages are automatically copied for instant use  
 🎛️ **Interactive Review Flow** - Accept, regenerate with new styles, or open the message in your editor before committing  
@@ -111,6 +112,27 @@ Or if running from source:
 ```bash
 go run cmd/commit-msg/main.go .
 ```
+
+### Preview Mode (Dry Run)
+
+Preview what would be sent to the LLM without making an API call:
+
+```bash
+commit . --dry-run
+```
+
+This displays:
+- The LLM provider that would be used
+- The exact prompt that would be sent
+- File statistics and change summary
+- Estimated token count
+- All without consuming API credits or sharing data
+
+Perfect for:
+- 🐛 **Debugging** - See exactly what prompt is being sent
+- 💰 **Cost Control** - Review before consuming API credits
+- 🔒 **Privacy** - Verify what data would be shared with external APIs
+- 🧪 **Development** - Test prompt changes without API calls
 
 ### Setup LLM and API Key
 

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -53,7 +53,8 @@ var creatCommitMsg = &cobra.Command{
 	Use:   ".",
 	Short: "Create Commit Message",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		CreateCommitMsg()
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		CreateCommitMsg(dryRun)
 		return nil
 	},
 }
@@ -68,6 +69,10 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	// Add --dry-run flag to the commit command
+	creatCommitMsg.Flags().Bool("dry-run", false, "Preview the prompt that would be sent to the LLM without making an API call")
+
 	rootCmd.AddCommand(creatCommitMsg)
 	rootCmd.AddCommand(llmCmd)
 	llmCmd.AddCommand(llmSetupCmd)


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
### Provided a way for users to see what the LLM sees when an API Call is made, without actually making one, using the ```commit . --dry-run``` command.
## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issue
<!-- Link to the issue this PR addresses -->
Fixes #92 

## Changes Made
<!-- List the specific changes made in this PR -->

* Added a --dry-run flag so the command is ``` commit . --dry-run```
* Added a function to display what the LLM sees entirely  during an API Call but no API call is actually made.
* Added the documentation in the README

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested with Gemini API
- [ ] Tested with Grok API
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Tested on macOS
- [ ] Added/updated tests (if applicable)

## Checklist
<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have tested this in a real Git repository
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->
## Command run when no changes made
![image](https://github.com/user-attachments/assets/7aebbe3b-f76a-4edd-8761-83fff0709745)

## Command run when changes made
- The message is a bit long as it contains the lines of code changed, added or deleted along with prompts, so can't provide screenshot but has been tested to be working.


## Additional Notes
<!-- Add any other context about the PR here -->

---

## For Hacktoberfest Participants
<!-- If this is a Hacktoberfest contribution, please check the box below -->

- [ ] This PR is submitted as part of Hacktoberfest 2025

Thank you for your contribution! 🎉

