### PR TITLE
Add unified LLM provider interface and refactor CLI integration

### DIFF
--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -1,0 +1,246 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/dfanso/commit-msg/internal/chatgpt"
+	"github.com/dfanso/commit-msg/internal/claude"
+	"github.com/dfanso/commit-msg/internal/gemini"
+	"github.com/dfanso/commit-msg/internal/grok"
+	"github.com/dfanso/commit-msg/internal/groq"
+	"github.com/dfanso/commit-msg/internal/ollama"
+	"github.com/dfanso/commit-msg/pkg/types"
+)
+
+// ErrMissingCredential signals that a provider requires a credential such as an API key or URL.
+var ErrMissingCredential = errors.New("llm: missing credential")
+
+// Provider declares the behaviour required by commit-msg to talk to an LLM backend.
+type Provider interface {
+	// Name returns the LLM provider identifier this instance represents.
+	Name() types.LLMProvider
+	// Generate requests a commit message for the supplied repository changes.
+	Generate(ctx context.Context, changes string, opts *types.GenerationOptions) (string, error)
+}
+
+// ProviderOptions captures the data needed to construct a provider instance.
+type ProviderOptions struct {
+	Credential string
+	Config     *types.Config
+}
+
+// Factory describes a function capable of building a Provider.
+type Factory func(ProviderOptions) (Provider, error)
+
+var (
+	factoryMu sync.RWMutex
+	factories = map[types.LLMProvider]Factory{
+		types.ProviderOpenAI: newOpenAIProvider,
+		types.ProviderClaude: newClaudeProvider,
+		types.ProviderGemini: newGeminiProvider,
+		types.ProviderGrok:   newGrokProvider,
+		types.ProviderGroq:   newGroqProvider,
+		types.ProviderOllama: newOllamaProvider,
+	}
+)
+
+// RegisterFactory allows callers (primarily tests) to override or extend provider creation logic.
+func RegisterFactory(name types.LLMProvider, factory Factory) {
+	factoryMu.Lock()
+	defer factoryMu.Unlock()
+	factories[name] = factory
+}
+
+// NewProvider returns a concrete Provider implementation for the requested name.
+func NewProvider(name types.LLMProvider, opts ProviderOptions) (Provider, error) {
+	factoryMu.RLock()
+	factory, ok := factories[name]
+	factoryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("llm: unsupported provider %s", name)
+	}
+
+	opts.Config = ensureConfig(opts.Config)
+	return factory(opts)
+}
+
+type missingCredentialError struct {
+	provider types.LLMProvider
+}
+
+func (e *missingCredentialError) Error() string {
+	return fmt.Sprintf("%s credential is required", e.provider.String())
+}
+
+func (e *missingCredentialError) Unwrap() error {
+	return ErrMissingCredential
+}
+
+func newMissingCredentialError(provider types.LLMProvider) error {
+	return &missingCredentialError{provider: provider}
+}
+
+func ensureConfig(cfg *types.Config) *types.Config {
+	if cfg != nil {
+		return cfg
+	}
+	return &types.Config{}
+}
+
+// --- Provider implementations ------------------------------------------------
+
+type openAIProvider struct {
+	apiKey string
+	config *types.Config
+}
+
+func newOpenAIProvider(opts ProviderOptions) (Provider, error) {
+	key := strings.TrimSpace(opts.Credential)
+	if key == "" {
+		key = strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	}
+	if key == "" {
+		return nil, newMissingCredentialError(types.ProviderOpenAI)
+	}
+	return &openAIProvider{apiKey: key, config: opts.Config}, nil
+}
+
+func (p *openAIProvider) Name() types.LLMProvider {
+	return types.ProviderOpenAI
+}
+
+func (p *openAIProvider) Generate(_ context.Context, changes string, opts *types.GenerationOptions) (string, error) {
+	return chatgpt.GenerateCommitMessage(p.config, changes, p.apiKey, opts)
+}
+
+type claudeProvider struct {
+	apiKey string
+	config *types.Config
+}
+
+func newClaudeProvider(opts ProviderOptions) (Provider, error) {
+	key := strings.TrimSpace(opts.Credential)
+	if key == "" {
+		key = strings.TrimSpace(os.Getenv("CLAUDE_API_KEY"))
+	}
+	if key == "" {
+		return nil, newMissingCredentialError(types.ProviderClaude)
+	}
+	return &claudeProvider{apiKey: key, config: opts.Config}, nil
+}
+
+func (p *claudeProvider) Name() types.LLMProvider {
+	return types.ProviderClaude
+}
+
+func (p *claudeProvider) Generate(_ context.Context, changes string, opts *types.GenerationOptions) (string, error) {
+	return claude.GenerateCommitMessage(p.config, changes, p.apiKey, opts)
+}
+
+type geminiProvider struct {
+	apiKey string
+	config *types.Config
+}
+
+func newGeminiProvider(opts ProviderOptions) (Provider, error) {
+	key := strings.TrimSpace(opts.Credential)
+	if key == "" {
+		key = strings.TrimSpace(os.Getenv("GEMINI_API_KEY"))
+	}
+	if key == "" {
+		return nil, newMissingCredentialError(types.ProviderGemini)
+	}
+	return &geminiProvider{apiKey: key, config: opts.Config}, nil
+}
+
+func (p *geminiProvider) Name() types.LLMProvider {
+	return types.ProviderGemini
+}
+
+func (p *geminiProvider) Generate(_ context.Context, changes string, opts *types.GenerationOptions) (string, error) {
+	return gemini.GenerateCommitMessage(p.config, changes, p.apiKey, opts)
+}
+
+type grokProvider struct {
+	apiKey string
+	config *types.Config
+}
+
+func newGrokProvider(opts ProviderOptions) (Provider, error) {
+	key := strings.TrimSpace(opts.Credential)
+	if key == "" {
+		key = strings.TrimSpace(os.Getenv("GROK_API_KEY"))
+	}
+	if key == "" {
+		return nil, newMissingCredentialError(types.ProviderGrok)
+	}
+	return &grokProvider{apiKey: key, config: opts.Config}, nil
+}
+
+func (p *grokProvider) Name() types.LLMProvider {
+	return types.ProviderGrok
+}
+
+func (p *grokProvider) Generate(_ context.Context, changes string, opts *types.GenerationOptions) (string, error) {
+	return grok.GenerateCommitMessage(p.config, changes, p.apiKey, opts)
+}
+
+type groqProvider struct {
+	apiKey string
+	config *types.Config
+}
+
+func newGroqProvider(opts ProviderOptions) (Provider, error) {
+	key := strings.TrimSpace(opts.Credential)
+	if key == "" {
+		key = strings.TrimSpace(os.Getenv("GROQ_API_KEY"))
+	}
+	if key == "" {
+		return nil, newMissingCredentialError(types.ProviderGroq)
+	}
+	return &groqProvider{apiKey: key, config: opts.Config}, nil
+}
+
+func (p *groqProvider) Name() types.LLMProvider {
+	return types.ProviderGroq
+}
+
+func (p *groqProvider) Generate(_ context.Context, changes string, opts *types.GenerationOptions) (string, error) {
+	return groq.GenerateCommitMessage(p.config, changes, p.apiKey, opts)
+}
+
+type ollamaProvider struct {
+	url    string
+	model  string
+	config *types.Config
+}
+
+func newOllamaProvider(opts ProviderOptions) (Provider, error) {
+	url := strings.TrimSpace(opts.Credential)
+	if url == "" {
+		url = strings.TrimSpace(os.Getenv("OLLAMA_URL"))
+		if url == "" {
+			url = "http://localhost:11434/api/generate"
+		}
+	}
+
+	model := strings.TrimSpace(os.Getenv("OLLAMA_MODEL"))
+	if model == "" {
+		model = "llama3.1"
+	}
+
+	return &ollamaProvider{url: url, model: model, config: opts.Config}, nil
+}
+
+func (p *ollamaProvider) Name() types.LLMProvider {
+	return types.ProviderOllama
+}
+
+func (p *ollamaProvider) Generate(_ context.Context, changes string, opts *types.GenerationOptions) (string, error) {
+	return ollama.GenerateCommitMessage(p.config, changes, p.url, p.model, opts)
+}

--- a/internal/llm/provider_test.go
+++ b/internal/llm/provider_test.go
@@ -1,0 +1,130 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dfanso/commit-msg/pkg/types"
+)
+
+func TestNewProviderRequiresCredential(t *testing.T) {
+	remoteProviders := []types.LLMProvider{
+		types.ProviderOpenAI,
+		types.ProviderClaude,
+		types.ProviderGemini,
+		types.ProviderGrok,
+		types.ProviderGroq,
+	}
+
+	for _, provider := range remoteProviders {
+		provider := provider
+		t.Run(provider.String(), func(t *testing.T) {
+			switch provider {
+			case types.ProviderOpenAI:
+				t.Setenv("OPENAI_API_KEY", "")
+			case types.ProviderClaude:
+				t.Setenv("CLAUDE_API_KEY", "")
+			case types.ProviderGemini:
+				t.Setenv("GEMINI_API_KEY", "")
+			case types.ProviderGrok:
+				t.Setenv("GROK_API_KEY", "")
+			case types.ProviderGroq:
+				t.Setenv("GROQ_API_KEY", "")
+			}
+
+			_, err := NewProvider(provider, ProviderOptions{})
+			if !errors.Is(err, ErrMissingCredential) {
+				t.Fatalf("expected ErrMissingCredential for %s, got %v", provider, err)
+			}
+		})
+	}
+}
+
+func TestNewProviderUsesEnvFallback(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "env-key")
+	provider, err := NewProvider(types.ProviderOpenAI, ProviderOptions{})
+	if err != nil {
+		t.Fatalf("expected no error using env fallback, got %v", err)
+	}
+
+	p, ok := provider.(*openAIProvider)
+	if !ok {
+		t.Fatalf("expected *openAIProvider, got %T", provider)
+	}
+
+	if p.apiKey != "env-key" {
+		t.Fatalf("expected api key to come from env, got %q", p.apiKey)
+	}
+}
+
+func TestNewProviderUnsupported(t *testing.T) {
+	_, err := NewProvider(types.LLMProvider("unknown"), ProviderOptions{})
+	if err == nil {
+		t.Fatal("expected error for unsupported provider")
+	}
+}
+
+func TestNewProviderOllamaDefaults(t *testing.T) {
+	t.Setenv("OLLAMA_URL", "")
+	t.Setenv("OLLAMA_MODEL", "")
+
+	provider, err := NewProvider(types.ProviderOllama, ProviderOptions{})
+	if err != nil {
+		t.Fatalf("expected no error for ollama provider, got %v", err)
+	}
+
+	p, ok := provider.(*ollamaProvider)
+	if !ok {
+		t.Fatalf("expected *ollamaProvider, got %T", provider)
+	}
+
+	if p.url == "" {
+		t.Fatalf("expected default URL to be set")
+	}
+
+	if p.model == "" {
+		t.Fatalf("expected default model to be set")
+	}
+}
+
+func TestRegisterFactoryOverrides(t *testing.T) {
+	factoryMu.Lock()
+	original := factories[types.ProviderOpenAI]
+	factoryMu.Unlock()
+
+	t.Cleanup(func() {
+		RegisterFactory(types.ProviderOpenAI, original)
+	})
+
+	called := 0
+	RegisterFactory(types.ProviderOpenAI, func(opts ProviderOptions) (Provider, error) {
+		called++
+		return fakeProvider{name: types.ProviderOpenAI}, nil
+	})
+
+	provider, err := NewProvider(types.ProviderOpenAI, ProviderOptions{})
+	if err != nil {
+		t.Fatalf("expected no error from overridden factory, got %v", err)
+	}
+
+	if called != 1 {
+		t.Fatalf("expected overridden factory to be called once, got %d", called)
+	}
+
+	if provider.Name() != types.ProviderOpenAI {
+		t.Fatalf("expected provider name %s, got %s", types.ProviderOpenAI, provider.Name())
+	}
+}
+
+type fakeProvider struct {
+	name types.LLMProvider
+}
+
+func (f fakeProvider) Name() types.LLMProvider {
+	return f.name
+}
+
+func (f fakeProvider) Generate(context.Context, string, *types.GenerationOptions) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This PR introduces a reusable LLM provider interface with factory-based construction and refactors the commit message workflow to depend on it. It consolidates provider-specific logic, standardizes credential handling, and improves error messages so new providers can be added with minimal wiring.

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issue
<!-- Link to the issue this PR addresses -->
Fixes #9

## Changes Made
<!-- List the specific changes made in this PR -->

- Introduced `internal/llm` with a provider interface, factory registry, and concrete adapters for each existing LLM backend.
- Refactored `CreateCommitMsg` to instantiate providers through the new abstraction, reuse them across regenerations, and surface clearer credential guidance.
- Added unit tests covering credential fallbacks, Ollama defaults, and factory overrides while preserving Groq test hooks.

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested with Gemini API
- [ ] Tested with Grok API
- [x] Tested on Windows
- [ ] Tested on Linux
- [ ] Tested on macOS
- [x] Added/updated tests (if applicable)

## Checklist
<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested this in a real Git repository
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

N/A

## Additional Notes
<!-- Add any other context about the PR here -->

- Providers can now be registered via `llm.RegisterFactory`, enabling easy experimentation with new backends without modifying the CLI.

---

## For Hacktoberfest Participants
<!-- If this is a Hacktoberfest contribution, please check the box below -->

- [x] This PR is submitted as part of Hacktoberfest 2025


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Pluggable LLM provider system with support for OpenAI, Claude, Gemini, Grok, Groq, and Ollama.
  * Clear, provider-specific guidance when credentials are missing.
  * Automatic use of environment variables for credentials where available.
  * Sensible defaults and setup hints for Ollama (URL/model), including dry-run support.

* Refactor
  * Unified message generation via a single provider interface for more consistent behavior across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->