### PR TITLE
fix #84  : properly handle git command errors in GetFileStatistics

### DIFF
--- a/internal/stats/statistics.go
+++ b/internal/stats/statistics.go
@@ -21,21 +21,30 @@ func GetFileStatistics(config *types.RepoConfig) (*display.FileStatistics, error
 	// Get staged files
 	stagedCmd := exec.Command("git", "-C", config.Path, "diff", "--name-only", "--cached")
 	stagedOutput, err := stagedCmd.Output()
-	if err == nil && len(stagedOutput) > 0 {
+	if err != nil {
+		return nil, fmt.Errorf("failed to get staged files: %w", err)
+	}
+	if len(stagedOutput) > 0 {
 		stats.StagedFiles = strings.Split(strings.TrimSpace(string(stagedOutput)), "\n")
 	}
 
 	// Get unstaged files
 	unstagedCmd := exec.Command("git", "-C", config.Path, "diff", "--name-only")
 	unstagedOutput, err := unstagedCmd.Output()
-	if err == nil && len(unstagedOutput) > 0 {
+	if err != nil {
+		return nil, fmt.Errorf("failed to get unstaged files: %w", err)
+	}
+	if len(unstagedOutput) > 0 {
 		stats.UnstagedFiles = strings.Split(strings.TrimSpace(string(unstagedOutput)), "\n")
 	}
 
 	// Get untracked files
 	untrackedCmd := exec.Command("git", "-C", config.Path, "ls-files", "--others", "--exclude-standard")
 	untrackedOutput, err := untrackedCmd.Output()
-	if err == nil && len(untrackedOutput) > 0 {
+	if err != nil {
+		return nil, fmt.Errorf("failed to get untracked files: %w", err)
+	}
+	if len(untrackedOutput) > 0 {
 		stats.UntrackedFiles = strings.Split(strings.TrimSpace(string(untrackedOutput)), "\n")
 	}
 
@@ -50,7 +59,10 @@ func GetFileStatistics(config *types.RepoConfig) (*display.FileStatistics, error
 	if len(stats.StagedFiles) > 0 {
 		statCmd := exec.Command("git", "-C", config.Path, "diff", "--cached", "--numstat")
 		statOutput, err := statCmd.Output()
-		if err == nil {
+		if err != nil {
+			return nil, fmt.Errorf("failed to get line statistics: %w", err)
+		}
+		if len(statOutput) > 0 {
 			lines := strings.Split(strings.TrimSpace(string(statOutput)), "\n")
 			for _, line := range lines {
 				parts := strings.Fields(line)

--- a/internal/stats/statistics_test.go
+++ b/internal/stats/statistics_test.go
@@ -24,12 +24,13 @@ func TestGetFileStatistics(t *testing.T) {
 			Path: "/non/existent/path",
 		}
 
-		// The function should not panic and should return some stats
+		// The function should return an error for non-existent directory
 		stats, err := GetFileStatistics(config)
-		// It may not return an error, but should handle it gracefully
-		_ = err
-		if stats == nil {
-			t.Fatal("expected stats to be returned even for non-existent directory")
+		if err == nil {
+			t.Fatal("expected error for non-existent directory")
+		}
+		if stats != nil {
+			t.Fatal("expected nil stats when error occurs")
 		}
 	})
 
@@ -41,12 +42,13 @@ func TestGetFileStatistics(t *testing.T) {
 			Path: dir,
 		}
 
-		// The function should not panic and should return some stats
+		// The function should return an error for non-git directory
 		stats, err := GetFileStatistics(config)
-		// It may not return an error, but should handle it gracefully
-		_ = err
-		if stats == nil {
-			t.Fatal("expected stats to be returned even for non-git directory")
+		if err == nil {
+			t.Fatal("expected error for non-git directory")
+		}
+		if stats != nil {
+			t.Fatal("expected nil stats when error occurs")
 		}
 	})
 


### PR DESCRIPTION
- Return descriptive errors when git commands fail instead of silently continuing with empty statistics
- Prevent misleading "no changes" display when git operations encounter issues
- Update tests to expect errors for invalid repository scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when retrieving staged, unstaged, and untracked files, ensuring failures are surfaced immediately.
  * Enhanced reliability when collecting line-change statistics; operations now stop with a clear error if retrieval fails.
  * For invalid or non-repository directories, file statistics now return explicit errors instead of ambiguous results.

* **Refactor**
  * Streamlined control flow to handle errors first, then process results, improving robustness.

* **Tests**
  * Updated tests to expect errors and no results for invalid and non-repository directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->