### PR TITLE
Fix DFanso#112 : add commit message length validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ commit
 test.txt
 AGENTS.md
 commit~
+commit-msg


### PR DESCRIPTION
- Add validation for commit message subject line length (50-72 char limit)
- Display warnings when messages exceed recommended limits
- Integrate validation into generation, regeneration, and editing workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds warnings when the commit message subject exceeds recommended or hard length limits, shown after generating, regenerating, or editing a message.

- Chores
  - Updated ignore rules to exclude commit message-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->