### PR TITLE
feat: handle large diffs by truncating before LLM input

### DIFF
--- a/cmd/cli/createMsg.go
+++ b/cmd/cli/createMsg.go
@@ -93,7 +93,7 @@ func CreateCommitMsg(Store *store.StoreMethods, dryRun bool, autoCommit bool) {
 
 	//  Large diff handling
 	const maxDiffChars = 8000 // can change as needed
-	const maxDiffLines = 300  
+	const maxDiffLines = 300
 
 	diffLines := strings.Split(changes, "\n")
 	diffTooLarge := len(changes) > maxDiffChars || len(diffLines) > maxDiffLines
@@ -103,18 +103,26 @@ func CreateCommitMsg(Store *store.StoreMethods, dryRun bool, autoCommit bool) {
 		pterm.Info.Printf("Diff size: %d lines, %d characters.\n", len(diffLines), len(changes))
 		pterm.Info.Println("Only the first part of the diff will be used for commit message generation.")
 
-		// Truncate the diff for LLM input
-		truncatedLines := diffLines
-		if len(diffLines) > maxDiffLines {
-			truncatedLines = diffLines[:maxDiffLines]
-		}
-		truncatedDiff := strings.Join(truncatedLines, "\n")
-		if len(truncatedDiff) > maxDiffChars {
-			truncatedDiff = truncatedDiff[:maxDiffChars]
-		}
-		changes = truncatedDiff
+		// Truncate the diff for LLM input, preserving whole lines and UTF-8 safety
+		truncatedLines := make([]string, 0, len(diffLines))
+		totalChars := 0
 
-		pterm.Info.Printf("Truncated diff to %d lines, %d characters.\n", len(strings.Split(changes, "\n")), len(changes))
+		for i, line := range diffLines {
+			lineLen := len([]rune(line)) + 1 // +1 for newline, using rune count for UTF-8 safety
+
+			// Stop if we've reached max lines or adding this line would exceed max chars
+			if i >= maxDiffLines || (totalChars+lineLen) > maxDiffChars {
+				break
+			}
+
+			truncatedLines = append(truncatedLines, line)
+			totalChars += lineLen
+		}
+
+		changes = strings.Join(truncatedLines, "\n")
+		actualLineCount := len(truncatedLines)
+
+		pterm.Info.Printf("Truncated diff to %d lines, %d characters.\n", actualLineCount, len(changes))
 		pterm.Info.Println("Consider committing smaller changes for more accurate commit messages.")
 	}
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Added logic to handle large Git diffs before sending them to the LLM for commit message generation.  
This ensures that very large diffs don’t exceed the model’s context window by truncating the input and warning the user.

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Other (please describe):

## Related Issue
<!-- Link to the issue this PR addresses -->
Fixes #90

## Changes Made
<!-- List the specific changes made in this PR -->

- Added constants `maxDiffChars` and `maxDiffLines` to define limits for diff size.
- Added logic to detect when a diff exceeds these limits.
- Added warnings and info messages using `pterm` to inform the user.
- Truncated oversized diffs to fit within the defined thresholds.
- Ensured that truncated diffs still proceed to LLM message generation.

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] Tested with Gemini API
- [ ] Tested with Grok API
- [ ] Tested on Windows
- [x] Tested on Linux
- [ ] Tested on macOS
- [x] Tested in a real Git repository with a large test file
- [ ] Added/updated tests (if applicable)

## Checklist
<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested this in a real Git repository
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

Output when testing with large diff:


```
 WARNING  The diff is very large and may exceed the LLM's context window.
 INFO  Diff size: 562 lines, 14350 characters.
 INFO  Only the first part of the diff will be used for commit message generation.
 INFO  Truncated diff to 300 lines, 7797 characters.
 INFO  Consider committing smaller changes for more accurate commit messages.

 SUCCESS  Commit message generated successfully!                                                         
 WARNING  Commit message subject line is 59 characters (recommended limit is 50)
```

## For Hacktoberfest Participants
<!-- If this is a Hacktoberfest contribution, please check the box below -->

- [x] This PR is submitted as part of Hacktoberfest 2025




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized diffs to prevent commit message generation failures: large changes are now detected and automatically truncated (preserving character boundaries) before being sent to the generator, with clear warnings and size details logged for transparency. Dry-run behavior is unchanged; truncation only affects the generated message preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->